### PR TITLE
Add OpenAPI/Swagger, change models and start service and controller implementation for resub

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,6 @@
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-core</artifactId>
-            <version>1.1.44</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>1.1.44</version>
         </dependency>
@@ -82,6 +77,33 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>pre-integration-test</id>
+                        <goals>
+                            <goal>start</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-integration-test</id>
+                        <goals>
+                            <goal>stop</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.springdoc</groupId>
+                <artifactId>springdoc-openapi-maven-plugin</artifactId>
+                <version>0.2</version>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,20 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-core</artifactId>
+            <version>1.1.44</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.1.44</version>
+        </dependency>
 
         <dependency>
             <groupId>com.h2database</groupId>

--- a/src/main/java/me/kverna/spring/repost/controller/ResubController.java
+++ b/src/main/java/me/kverna/spring/repost/controller/ResubController.java
@@ -2,10 +2,14 @@ package me.kverna.spring.repost.controller;
 
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import me.kverna.spring.repost.data.EditResub;
 import me.kverna.spring.repost.data.Resub;
+import me.kverna.spring.repost.data.User;
+import me.kverna.spring.repost.repository.UserRepository;
 import me.kverna.spring.repost.service.ResubService;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -15,13 +19,15 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/resub")
+@RequestMapping("/api/resubs")
 public class ResubController {
 
     private final ResubService service;
+    private UserRepository userRepository;
 
-    public ResubController(ResubService service) {
+    public ResubController(ResubService service, UserRepository userRepository) {
         this.service = service;
+        this.userRepository = userRepository;
     }
 
     @GetMapping(value = "/", produces = {"application/json"})
@@ -46,7 +52,10 @@ public class ResubController {
     })
     @PostMapping(value = "/", consumes = {"application/json"}, produces = {"application/json"})
     public Resub createResub(@RequestBody Resub resub) {
-        return service.createResub(null, resub);
+        User owner = new User();
+        owner.setUsername("Kåre");
+        owner.setBio("Er kul tbh");
+        return service.createResub(userRepository.save(owner), resub);
     }
 
     @ApiResponses(value = {
@@ -59,5 +68,14 @@ public class ResubController {
     @DeleteMapping(value = "/{resub}")
     public void deleteResub(@PathVariable String resub) {
         service.deleteResub(resub);
+    }
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "404")
+    })
+    @PatchMapping(value = "/{resub}", consumes = {"application/json"}, produces = {"application/json"})
+    public Resub editResub(@RequestBody EditResub editResub, @PathVariable String resub) {
+        return service.editResub(editResub, resub);
     }
 }

--- a/src/main/java/me/kverna/spring/repost/controller/ResubController.java
+++ b/src/main/java/me/kverna/spring/repost/controller/ResubController.java
@@ -1,0 +1,63 @@
+package me.kverna.spring.repost.controller;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import me.kverna.spring.repost.data.Resub;
+import me.kverna.spring.repost.service.ResubService;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/resub")
+public class ResubController {
+
+    private final ResubService service;
+
+    public ResubController(ResubService service) {
+        this.service = service;
+    }
+
+    @GetMapping(value = "/", produces = {"application/json"})
+    public List<Resub> getAllResubs() {
+        return service.getAllResubs();
+    }
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "404")
+    })
+    @GetMapping(value = "/{resub}", produces = {"application/json"})
+    public Resub getResub(@PathVariable String resub) {
+        return service.getResub(resub);
+    }
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400"),
+            @ApiResponse(responseCode = "401"),
+            @ApiResponse(responseCode = "404")
+    })
+    @PostMapping(value = "/", consumes = {"application/json"}, produces = {"application/json"})
+    public Resub createResub(@RequestBody Resub resub) {
+        return service.createResub(null, resub);
+    }
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200"),
+            @ApiResponse(responseCode = "400"),
+            @ApiResponse(responseCode = "401"),
+            @ApiResponse(responseCode = "403"),
+            @ApiResponse(responseCode = "404")
+    })
+    @DeleteMapping(value = "/{resub}")
+    public void deleteResub(@PathVariable String resub) {
+        service.deleteResub(resub);
+    }
+}

--- a/src/main/java/me/kverna/spring/repost/data/Comment.java
+++ b/src/main/java/me/kverna/spring/repost/data/Comment.java
@@ -41,7 +41,7 @@ public class Comment {
         return parent_resub.getName();
     }
 
-    @JsonProperty(value = "parent_resub_name", access = JsonProperty.Access.READ_ONLY)
+    @JsonProperty(value = "parent_post_id", access = JsonProperty.Access.READ_ONLY)
     public int getParentPostId() {
         return parent_post.getId();
     }

--- a/src/main/java/me/kverna/spring/repost/data/Comment.java
+++ b/src/main/java/me/kverna/spring/repost/data/Comment.java
@@ -1,5 +1,7 @@
 package me.kverna.spring.repost.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -22,10 +24,30 @@ public class Comment {
     private LocalDateTime created;
     private LocalDateTime edited;
 
+    @JsonIgnore
     @ManyToOne
     private User author;
+
+    @JsonIgnore
     @ManyToOne
     private Resub parent_resub;
+
+    @JsonIgnore
     @ManyToOne
     private Post parent_post;
+
+    @JsonProperty(value = "parent_resub_name", access = JsonProperty.Access.READ_ONLY)
+    public String getParentResubName() {
+        return parent_resub.getName();
+    }
+
+    @JsonProperty(value = "parent_resub_name", access = JsonProperty.Access.READ_ONLY)
+    public int getParentPostId() {
+        return parent_post.getId();
+    }
+
+    @JsonProperty(value = "author_username", access = JsonProperty.Access.READ_ONLY)
+    public String getAuthorUsername() {
+        return author.getUsername();
+    }
 }

--- a/src/main/java/me/kverna/spring/repost/data/EditResub.java
+++ b/src/main/java/me/kverna/spring/repost/data/EditResub.java
@@ -1,0 +1,19 @@
+package me.kverna.spring.repost.data;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class EditResub {
+    private String description;
+    @JsonIgnore
+    private String newOwnerUsername;
+
+    @JsonProperty(value = "new_owner_username")
+    public void setOwnerUsername(String ownerUsername) {
+        newOwnerUsername = ownerUsername;
+    }
+}

--- a/src/main/java/me/kverna/spring/repost/data/EditResub.java
+++ b/src/main/java/me/kverna/spring/repost/data/EditResub.java
@@ -9,11 +9,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class EditResub {
     private String description;
-    @JsonIgnore
-    private String newOwnerUsername;
-
     @JsonProperty(value = "new_owner_username")
-    public void setOwnerUsername(String ownerUsername) {
-        newOwnerUsername = ownerUsername;
-    }
+    private String newOwnerUsername;
 }

--- a/src/main/java/me/kverna/spring/repost/data/Post.java
+++ b/src/main/java/me/kverna/spring/repost/data/Post.java
@@ -1,5 +1,7 @@
 package me.kverna.spring.repost.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -20,17 +22,36 @@ import java.util.Set;
 public class Post {
     @Id
     @GeneratedValue
+    @JsonIgnore
     private int id;
     private String title;
     private String url;
     private String content;
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime created;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime edited;
 
+    @JsonIgnore
     @ManyToOne
     private User author;
+
+    @JsonIgnore
     @ManyToOne
     private Resub resub;
+
+    @JsonIgnore
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "parent_post")
     private Set<Comment> comments;
+
+    @JsonProperty(value = "parent_resub_name", access = JsonProperty.Access.READ_ONLY)
+    public String getParentResubName() {
+        return resub.getName();
+    }
+
+    @JsonProperty(value = "author_username", access = JsonProperty.Access.READ_ONLY)
+    public String getAuthorUsername() {
+        return author.getUsername();
+    }
 }

--- a/src/main/java/me/kverna/spring/repost/data/Resub.java
+++ b/src/main/java/me/kverna/spring/repost/data/Resub.java
@@ -1,5 +1,7 @@
 package me.kverna.spring.repost.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -20,16 +22,31 @@ import java.util.Set;
 public class Resub {
     @Id
     @GeneratedValue
+    @JsonIgnore
     private int id;
     private String name;
     private String description;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime created;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime edited;
 
+    @JsonIgnore
     @ManyToOne
     private User owner;
+
+    @JsonIgnore
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "resub")
     private Set<Post> posts;
+
+    @JsonIgnore
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "parent_resub")
     private Set<Comment> comments;
+
+    @JsonProperty(value = "owner_username", access = JsonProperty.Access.READ_ONLY)
+    public String getOwnerUsername() {
+        return owner.getUsername();
+    }
 }

--- a/src/main/java/me/kverna/spring/repost/data/User.java
+++ b/src/main/java/me/kverna/spring/repost/data/User.java
@@ -1,5 +1,7 @@
 package me.kverna.spring.repost.data;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -23,15 +25,25 @@ public class User {
     private String username;
     private String bio;
     private String avatar_url;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime created;
+
+    @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private LocalDateTime edited;
 
+    @JsonIgnore
     private String hashed_password;
 
+    @JsonIgnore
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "owner")
     private Set<Resub> resubs;
+
+    @JsonIgnore
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "author")
     private Set<Post> posts;
+
+    @JsonIgnore
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "author")
     private Set<Comment> comments;
 }

--- a/src/main/java/me/kverna/spring/repost/repository/ResubRepository.java
+++ b/src/main/java/me/kverna/spring/repost/repository/ResubRepository.java
@@ -6,4 +6,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ResubRepository extends JpaRepository<Resub, Integer> {
+    Resub findByName(String name);
+
+    void deleteByName(String name);
 }

--- a/src/main/java/me/kverna/spring/repost/service/ResubService.java
+++ b/src/main/java/me/kverna/spring/repost/service/ResubService.java
@@ -1,0 +1,92 @@
+package me.kverna.spring.repost.service;
+
+import me.kverna.spring.repost.data.Resub;
+import me.kverna.spring.repost.data.User;
+import me.kverna.spring.repost.repository.ResubRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+public class ResubService {
+
+    private ResubRepository repository;
+
+    @Autowired
+    public ResubService(ResubRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * Get all resubs.
+     *
+     * @return a list of all resubs.
+     */
+    public List<Resub> getAllResubs() {
+        return repository.findAll();
+    }
+
+    /**
+     * Get a resub by name.
+     *
+     * @param name the name of the resub.
+     * @return the resub with the given name.
+     */
+    public Resub getResub(String name) {
+        return repository.findByName(name);
+    }
+
+    /**
+     * Create a resub if no resub with the same name exists.
+     *
+     * @param owner the owner of the resub.
+     * @param resub the resub to create.
+     * @return the resub that is created.
+     */
+    public Resub createResub(User owner, Resub resub) {
+        Resub existingResub = repository.findByName(resub.getName());
+        if (existingResub != null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    String.format("Resub %s already exists", resub.getName()));
+        }
+
+        resub.setOwner(owner);
+        resub.setCreated(LocalDateTime.now());
+        return repository.save(resub);
+    }
+
+    /**
+     * Edit a resub by name.
+     *
+     * @param resub     the new resub fields.
+     * @param resubName the name of the resub to edit.
+     * @return the edited resub.
+     */
+    public Resub editResub(Resub resub, String resubName) {
+        Resub existingResub = repository.findByName(resubName);
+        if (existingResub == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    String.format("Resub %s was not found", resubName));
+        }
+
+        String description = resub.getDescription();
+        if (description != null) {
+            existingResub.setDescription(description);
+        }
+        existingResub.setEdited(LocalDateTime.now());
+        return repository.save(existingResub);
+    }
+
+    /**
+     * Delete a resub by name.
+     *
+     * @param name the name of the resub to delete.
+     */
+    public void deleteResub(String name) {
+        repository.deleteByName(name);
+    }
+}

--- a/src/main/java/me/kverna/spring/repost/service/ResubService.java
+++ b/src/main/java/me/kverna/spring/repost/service/ResubService.java
@@ -37,7 +37,13 @@ public class ResubService {
      * @return the resub with the given name.
      */
     public Resub getResub(String name) {
-        return repository.findByName(name);
+        Resub resub = repository.findByName(name);
+        if (resub == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                    String.format("Resub %s was not found", name));
+        }
+
+        return resub;
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,5 @@ spring.datasource.url=jdbc:h2:file:./repostdb
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+springdoc.api-docs.path=/api/springdoc
+springdoc.swagger-ui.path=/api/swagger


### PR DESCRIPTION
Models have been changed so that the json schema does not show all the information that the model holds in the database. Add new model for editing resub.

Add dependencies for OpenAPI and Swagger UI and start to use them in the resub controller.

Add resub service and controller. Only some endpoints are implemented.

Closes #21 

#8 and #13 are still in progress.