### PR TITLE
Implement repost-fastapi error model and support for excluding unset fields in patch endpoints

### DIFF
--- a/src/main/java/me/kverna/spring/repost/RestExceptionHandler.java
+++ b/src/main/java/me/kverna/spring/repost/RestExceptionHandler.java
@@ -1,0 +1,42 @@
+package me.kverna.spring.repost;
+
+import me.kverna.spring.repost.data.ErrorResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@ControllerAdvice
+public class RestExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatus status,
+            WebRequest request) {
+        FieldError error = ex.getBindingResult().getFieldError();
+        String message;
+        if (error != null) {
+            message = String.format("Failed to validate field %s: %s", error.getField(),
+                    error.getDefaultMessage());
+        } else {
+            message ="Failed to validate: " + ex.getMessage();
+        }
+
+        return handleExceptionInternal(ex, new ErrorResponse(message), headers,
+                HttpStatus.UNPROCESSABLE_ENTITY, request);
+    }
+
+    @ExceptionHandler({ResponseStatusException.class})
+    public ResponseEntity<Object> handleExceptions(Exception ex) {
+        ResponseStatusException statusEx = (ResponseStatusException) ex;
+
+        ErrorResponse response = new ErrorResponse(statusEx.getReason());
+        return new ResponseEntity<>(response, statusEx.getResponseHeaders(), statusEx.getStatus());
+    }
+}

--- a/src/main/java/me/kverna/spring/repost/controller/CommentController.java
+++ b/src/main/java/me/kverna/spring/repost/controller/CommentController.java
@@ -1,12 +1,15 @@
 package me.kverna.spring.repost.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import me.kverna.spring.repost.data.Comment;
 import me.kverna.spring.repost.data.CreateComment;
 import me.kverna.spring.repost.data.EditComment;
+import me.kverna.spring.repost.data.ErrorResponse;
 import me.kverna.spring.repost.data.Post;
 import me.kverna.spring.repost.data.User;
 import me.kverna.spring.repost.security.AuthorizeUser;
@@ -37,9 +40,9 @@ public class CommentController {
             summary = "Create Reply", description = "Create a reply to a comment.",
             responses = {
                     @ApiResponse(responseCode = "201", description = "Successful Response"),
-                    @ApiResponse(responseCode = "400", description = "Bad Request"),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             },
             security = @SecurityRequirement(name = "OAuth2PasswordBearer", scopes = "user")
     )
@@ -57,10 +60,10 @@ public class CommentController {
             "Only the author of a comment can edit the comment.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "400", description = "Bad Request"),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized"),
-                    @ApiResponse(responseCode = "403", description = "Forbidden"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             },
             security = @SecurityRequirement(name = "OAuth2PasswordBearer", scopes = "user")
     )
@@ -75,10 +78,10 @@ public class CommentController {
             "Only the author of the comment or the owner of the parent resub can delete the comment.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "400", description = "Bad Request"),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized"),
-                    @ApiResponse(responseCode = "403", description = "Forbidden"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             },
             security = @SecurityRequirement(name = "OAuth2PasswordBearer", scopes = "user")
 

--- a/src/main/java/me/kverna/spring/repost/controller/PostController.java
+++ b/src/main/java/me/kverna/spring/repost/controller/PostController.java
@@ -1,12 +1,16 @@
 package me.kverna.spring.repost.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
 import me.kverna.spring.repost.data.Comment;
 import me.kverna.spring.repost.data.CreateComment;
 import me.kverna.spring.repost.data.EditPost;
+import me.kverna.spring.repost.data.ErrorResponse;
 import me.kverna.spring.repost.data.Post;
 import me.kverna.spring.repost.data.User;
 import me.kverna.spring.repost.security.AuthorizeUser;
@@ -43,7 +47,7 @@ public class PostController {
             summary = "Get Post", description = "Get a specific post.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping(value = "/{postId}", produces = {"application/json"})
@@ -55,16 +59,16 @@ public class PostController {
             summary = "Edit Post", description = "Edit a post.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "400", description = "Bad Request"),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized"),
-                    @ApiResponse(responseCode = "403", description = "Forbidden"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             },
             security = @SecurityRequirement(name = "OAuth2PasswordBearer", scopes = "user")
     )
     @AuthorizeUser
     @PatchMapping(value = "/{postId}", consumes = {"application/patch+json"}, produces = {"application/json"})
-    public Post editPost(@PathVariable int postId, @RequestBody EditPost editPost, @CurrentUser User user) {
+    public Post editPost(@PathVariable int postId, @RequestBody @Valid EditPost editPost, @CurrentUser User user) {
         return service.editPost(editPost, service.getPost(postId), user);
     }
 
@@ -73,10 +77,10 @@ public class PostController {
             "Only the author of the post or the owner of the parent resub can delete the post.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "400", description = "Bad Request"),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized"),
-                    @ApiResponse(responseCode = "403", description = "Forbidden"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             },
             security = @SecurityRequirement(name = "OAuth2PasswordBearer", scopes = "user")
 
@@ -91,9 +95,9 @@ public class PostController {
             summary = "Create Comment In Post", description = "Create a comment in a post.",
             responses = {
                     @ApiResponse(responseCode = "201", description = "Successful Response"),
-                    @ApiResponse(responseCode = "400", description = "Bad Request"),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             },
             security = @SecurityRequirement(name = "OAuth2PasswordBearer", scopes = "user")
     )
@@ -109,7 +113,7 @@ public class PostController {
             summary = "Get Comments In Post", description = "Get all comments in post.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping(value = "/{postId}/comments", produces = {"application/json"})

--- a/src/main/java/me/kverna/spring/repost/controller/ResubController.java
+++ b/src/main/java/me/kverna/spring/repost/controller/ResubController.java
@@ -1,12 +1,15 @@
 package me.kverna.spring.repost.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import me.kverna.spring.repost.data.CreatePost;
 import me.kverna.spring.repost.data.CreateResub;
 import me.kverna.spring.repost.data.EditResub;
+import me.kverna.spring.repost.data.ErrorResponse;
 import me.kverna.spring.repost.data.Post;
 import me.kverna.spring.repost.data.Resub;
 import me.kverna.spring.repost.data.User;
@@ -55,7 +58,7 @@ public class ResubController {
             summary = "Get Resub", description = "Get a specific resub.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping(value = "/{resub}", produces = {"application/json"})
@@ -67,8 +70,8 @@ public class ResubController {
             summary = "Create Resub", description = "Create a new resub.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "400", description = "Bad Request"),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized")
+                    @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             },
             security = @SecurityRequirement(name = "OAuth2PasswordBearer", scopes = "user")
     )
@@ -84,10 +87,10 @@ public class ResubController {
             "Only the owner of a resub can delete the resub.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "400", description = "Bad Request"),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized"),
-                    @ApiResponse(responseCode = "403", description = "Forbidden"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             },
             security = @SecurityRequirement(name = "OAuth2PasswordBearer", scopes = "user")
     )
@@ -102,10 +105,10 @@ public class ResubController {
             "Only the owner of a resub can edit the resub.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "400", description = "Bad Request"),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized"),
-                    @ApiResponse(responseCode = "403", description = "Forbidden"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "403", description = "Forbidden", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             },
             security = @SecurityRequirement(name = "OAuth2PasswordBearer", scopes = "user")
     )
@@ -119,7 +122,7 @@ public class ResubController {
             summary = "Create Post In Resub", description = "Create new post in a resub.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             },
             security = @SecurityRequirement(name = "OAuth2PasswordBearer", scopes = "user")
     )
@@ -134,7 +137,7 @@ public class ResubController {
             summary = "Get Posts In Resub", description = "Get all posts in a resub.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping(value = "/{resub}/posts", produces = {"application/json"})

--- a/src/main/java/me/kverna/spring/repost/controller/UserController.java
+++ b/src/main/java/me/kverna/spring/repost/controller/UserController.java
@@ -1,12 +1,15 @@
 package me.kverna.spring.repost.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import me.kverna.spring.repost.data.Comment;
 import me.kverna.spring.repost.data.CreateUser;
 import me.kverna.spring.repost.data.EditUser;
+import me.kverna.spring.repost.data.ErrorResponse;
 import me.kverna.spring.repost.data.Post;
 import me.kverna.spring.repost.data.Resub;
 import me.kverna.spring.repost.data.User;
@@ -62,8 +65,8 @@ public class UserController {
             summary = "Get Current User", description = "Get the authorized user.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "400", description = "Bad Request"),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized")
+                    @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             },
             security = @SecurityRequirement(name = "OAuth2PasswordBearer", scopes = "user")
     )
@@ -77,8 +80,8 @@ public class UserController {
             summary = "Edit Current User", description = "Edit the currently authorized user.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "400", description = "Bad Request"),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized")
+                    @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             },
             security = @SecurityRequirement(name = "OAuth2PasswordBearer", scopes = "user")
     )
@@ -92,8 +95,8 @@ public class UserController {
             summary = "Delete Current User", description = "Delete the currently authorized user.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "400", description = "Bad Request"),
-                    @ApiResponse(responseCode = "401", description = "Unauthorized")
+                    @ApiResponse(responseCode = "400", description = "Bad Request", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             },
             security = @SecurityRequirement(name = "OAuth2PasswordBearer", scopes = "user")
     )
@@ -107,7 +110,7 @@ public class UserController {
             summary = "Get User", description = "Get a specific user.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping(value = "/{username}", produces = {"application/json"})
@@ -119,7 +122,7 @@ public class UserController {
             summary = "Get Resubs Owned By User", description = "Get all resubs owned by specific user.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping(value = "/{username}/resubs", produces = {"application/json"})
@@ -132,7 +135,7 @@ public class UserController {
             summary = "Get Posts Owned By User", description = "Get all posts owned by specific user.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping(value = "/{username}/posts", produces = {"application/json"})
@@ -145,7 +148,7 @@ public class UserController {
             summary = "Get Comments By User", description = "Get all comments owned by specific user.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "Successful Response"),
-                    @ApiResponse(responseCode = "404", description = "Not Found")
+                    @ApiResponse(responseCode = "404", description = "Not Found", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             }
     )
     @GetMapping(value = "/{username}/comments", produces = {"application/json"})

--- a/src/main/java/me/kverna/spring/repost/data/EditComment.java
+++ b/src/main/java/me/kverna/spring/repost/data/EditComment.java
@@ -1,6 +1,5 @@
 package me.kverna.spring.repost.data;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/me/kverna/spring/repost/data/EditPost.java
+++ b/src/main/java/me/kverna/spring/repost/data/EditPost.java
@@ -1,6 +1,5 @@
 package me.kverna.spring.repost.data;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.Optional;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -8,7 +7,8 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class EditPost {
-    private String title;
+
+    private Optional<String> title;
     private Optional<String> content;
     private Optional<String> url;
 }

--- a/src/main/java/me/kverna/spring/repost/data/EditResub.java
+++ b/src/main/java/me/kverna/spring/repost/data/EditResub.java
@@ -1,6 +1,5 @@
 package me.kverna.spring.repost.data;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
 import lombok.Data;

--- a/src/main/java/me/kverna/spring/repost/data/EditUser.java
+++ b/src/main/java/me/kverna/spring/repost/data/EditUser.java
@@ -1,6 +1,5 @@
 package me.kverna.spring.repost.data;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Optional;
 import lombok.Data;

--- a/src/main/java/me/kverna/spring/repost/data/ErrorResponse.java
+++ b/src/main/java/me/kverna/spring/repost/data/ErrorResponse.java
@@ -1,0 +1,13 @@
+package me.kverna.spring.repost.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private String detail;
+}

--- a/src/main/java/me/kverna/spring/repost/data/Post.java
+++ b/src/main/java/me/kverna/spring/repost/data/Post.java
@@ -2,9 +2,8 @@ package me.kverna.spring.repost.data;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
+import java.time.LocalDateTime;
+import java.util.Set;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -12,14 +11,15 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
-import java.time.LocalDateTime;
-import java.util.Set;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Table(name = "posts")
 @Entity
 @NoArgsConstructor
 public class Post {
+
     @Id
     @GeneratedValue
     private int id;

--- a/src/main/java/me/kverna/spring/repost/service/CommentService.java
+++ b/src/main/java/me/kverna/spring/repost/service/CommentService.java
@@ -76,9 +76,11 @@ public class CommentService {
                     "You are not the author of this comment");
         }
 
-        if (editComment.getContent() != null) {
-            comment.setContent(editComment.getContent());
+        if (editComment.getContent() == null) {
+            throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                    "Failed to validate field title: can't be null");
         }
+        comment.setContent(editComment.getContent());
         comment.setEdited(LocalDateTime.now());
 
         return repository.save(comment);

--- a/src/main/java/me/kverna/spring/repost/service/PostService.java
+++ b/src/main/java/me/kverna/spring/repost/service/PostService.java
@@ -95,7 +95,10 @@ public class PostService {
         }
 
         if (editPost.getTitle() != null) {
-            post.setTitle(editPost.getTitle());
+            if (editPost.getTitle().isEmpty()) {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Post title can't be null");
+            }
+            post.setTitle(editPost.getTitle().get());
         }
         if (editPost.getContent() != null) {
             post.setContent(editPost.getContent().isEmpty() ? null : editPost.getContent().get());

--- a/src/main/java/me/kverna/spring/repost/service/PostService.java
+++ b/src/main/java/me/kverna/spring/repost/service/PostService.java
@@ -96,7 +96,8 @@ public class PostService {
 
         if (editPost.getTitle() != null) {
             if (editPost.getTitle().isEmpty()) {
-                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY, "Post title can't be null");
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY,
+                        "Failed to validate field title: can't be null");
             }
             post.setTitle(editPost.getTitle().get());
         }


### PR DESCRIPTION
resolves #38, resolves #33 

Adds exception handler for formatting all errors as a simple 

```json
{
   "detail": ""
}
```

Does not fully implement validation (#26). This only applies to partial patch with JSON schema.